### PR TITLE
genomic_snp start/end validation logic

### DIFF
--- a/src/beacon_api/utils/validate.py
+++ b/src/beacon_api/utils/validate.py
@@ -225,7 +225,7 @@ def validate(endpoint):
             elif endpoint == "genomic_region":
                 start = obj.get("start")
                 end = obj.get("end")
-                if end < start:
+                if end <= start:
                     raise BeaconBadRequest(obj, request.host, "'end' must be greater than 'start'")
             elif endpoint == "sample_list":
                 further_validation_sample(request, obj)


### PR DESCRIPTION
start is 0 based inclusive where as end is 0 based exclusive, meaning that end must be 1 more than start at least. if start == end then x must both be included and excluded from the search which is not possible.

- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation


related to issue #9 
